### PR TITLE
make sure we do copy even when a selection already exists in the document

### DIFF
--- a/clipboard-copy.html
+++ b/clipboard-copy.html
@@ -70,15 +70,19 @@ the License.
      * @return {Boolean} True if the content has been copied to the clipboard
      * and false if there was an error.
      */
-    copy() {
+     copy() {
       if (this._beforeCopy()) {
         return this._notifyCopied();
       }
       this.setAttribute('copying', true);
-      var range = document.createRange();
+      const range = document.createRange();
       range.selectNode(this.$.content);
-      window.getSelection().addRange(range);
-      var result = false;
+      const sel = window.getSelection();
+      // Note(cg): we need to remove all selections before - otherwise nothing happens
+      // see https://stackoverflow.com/questions/45090073/chrome-selection-addrange-does-not-select-an-execcommandcopy-use-case.
+      sel.removeAllRanges();
+      sel.addRange(range);
+      let result = false;
       try {
         result = document.execCommand('copy');
         this._notifyCopied();


### PR DESCRIPTION
copy to clipboard does not work when there is already a selection in the document (https://stackoverflow.com/questions/45090073/chrome-selection-addrange-does-not-select-an-execcommandcopy-use-case)

This PR removes all potentially selection before copying

